### PR TITLE
GCC 15 compatibility fix + USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,265 @@
+# nissutils — USAGE
+
+## Purpose
+
+nissutils is a collection of command-line tools for working with Nissan ECU
+ROMs (roughly 2000–2017). They handle checksum correction, encryption,
+key derivation, binary analysis, and ROM identification.
+
+All tools are standalone executables — no install required.
+
+---
+
+## Tools
+
+### nisrom — ROM analysis
+
+Identify and validate a Nissan ROM dump. Reports ECU family, FID (firmware ID),
+checksum locations, keyset quality, s27k/s36k keys, EEPROM read address, and
+MD5 hash.
+
+```
+nisrom <ROMFILE> [OPTIONS]
+
+OPTIONS:
+  -v    human-readable output (default if no -c/-l given)
+  -c    CSV output (values only)
+  -l    CSV headers — can combine with -c, or use alone without ROMFILE
+  -h    show help
+  -f    force parsing, ignore errors [DANGEROUS — may crash or produce wrong output]
+```
+
+**Key output fields:**
+
+| Field | Description |
+|-------|-------------|
+| ECUID | Extracted from filename (first `-`/`_`-delimited token if 5 chars) |
+| FID | Firmware ID string embedded in ROM (e.g. `1Q6MAZNV`) — the Cal ID |
+| std cks? | 1 if standard checksum valid; `&std_s` and `&std_x` give locations |
+| s27k / s36k1 | Security keys extracted directly from ROM binary |
+| &EEPROM_read() | File offset of `eeprom_read()` function — use with `npconf eepr` in nisprog |
+| MD5 | ROM file hash — useful for confirming dump integrity |
+
+**Examples:**
+
+```
+nisrom rom.bin              # identify ROM — human readable
+nisrom rom.bin -c -l        # CSV with headers — pipe to spreadsheet
+nisrom -l                   # print CSV column headers only (no ROM file needed)
+```
+
+**AI notes:**
+- `nisrom` is **analysis only** — it never modifies the ROM file. There is no
+  `--fix` flag. Use `nisckfix1` or `nisckfix2` to fix checksums after editing.
+- **`nisrom` derives s27k/s36k directly from the ROM binary** via code analysis
+  (`find_s27_hardcore`) and brute-force fallback. If `keyset quality` > 0, the
+  output s27k/s36k are usable directly in `nisprog setkeys`. This is the primary
+  way to get keys for a ROM not in nisprog's bundled DB.
+- **ECUID comes from the filename**, not ROM contents. Name the file with the
+  ECUID as the first token (e.g. `6S710.bin` or `MEC07-370C1.bin`) for correct
+  ECUID display. A file named `rom.bin` will not show an ECUID.
+- `&std_s` and `&std_x` from the output are the arguments to pass to
+  `nisckfix1`/`nisckfix2` after editing the ROM.
+- `&EEPROM_read()` from the output is the address to pass to `npconf eepr`
+  in nisprog before running `dm <file> 0 512 eep`.
+- Debug output is written to `nisrom_dbg.log` in the current directory.
+- `-f` (force parse) may cause segfaults. Do not use on clean workflows.
+
+---
+
+### nisckfix1 — Fix checksum (correction-value strategy)
+
+Rewrites the three correction u32 values that bring the ROM checksum into
+agreement. Use when the checksum block address is known.
+
+```
+nisckfix1 <&cks_s> <&cks_x> <&corrections> <in_file> [<out_file>]
+```
+
+All address arguments are file offsets in hex. If `out_file` is omitted,
+output goes to `temp.bin`.
+
+**Example:**
+
+```
+nisckfix1 757c 7574 0xbfff4 patched.bin fixed.bin
+```
+
+**AI notes:**
+- Use `nisrom rom.bin` to get `&std_s` and `&std_x` before calling nisckfix.
+- `nisckfix1` takes three address arguments; `nisckfix2` takes two (no `&corrections`).
+- All addresses are **file offsets** — not hardware VAs.
+- If `out_file` is omitted, output goes to `temp.bin`. Never let `temp.bin`
+  accumulate in a directory with original ROM files.
+
+---
+
+### nisckfix2 — Fix checksum (rewrite-values strategy)
+
+Alternative checksum fix that directly overwrites the checksum storage
+locations rather than adjusting correction values.
+
+```
+nisckfix2 <&cks_s> <&cks_x> <in_file> [<out_file>]
+```
+
+**Example:**
+
+```
+nisckfix2 757c 7574 patched.bin fixed.bin
+```
+
+---
+
+### nisdec1 — Decrypt ROM / data file
+
+Decrypt a file using the Nissan NPT_DDL algorithm.
+
+```
+nisdec1 <scode> <in_file> [<out_file>]
+```
+
+`scode` is a uint32 hex value (the seed/key).
+
+**Example:**
+
+```
+nisdec1 55AA00FF encrypted.bin decrypted.bin
+```
+
+---
+
+### nisenc1 — Encrypt ROM / data file
+
+Encrypt a file using Nissan Algo 01.
+
+```
+nisenc1 <scode> <in_file> [<out_file>]
+```
+
+**Example:**
+
+```
+nisenc1 55AA00FF plain.bin encrypted.bin
+```
+
+---
+
+### nisguess — Derive key from known enc/dec pair
+
+List possible keys that encode a given pair of uint32 values. Useful when
+you have one known plaintext/ciphertext pair.
+
+```
+nisguess <enc> <dec>
+```
+
+Both arguments are uint32 hex values.
+
+**AI notes:**
+- `nisguess` / `nisguess2` are brute-force tools — runtime scales with key
+  space. They require at least one known plaintext/ciphertext pair.
+- If the ROM is available, run `nisrom rom.bin` first — it may extract s27k/s36k
+  directly from the binary without needing nisguess.
+
+---
+
+### nisguess2 — Guess key from enc/dec file pair
+
+Attempt to derive the Nissan encryption key from a pair of encrypted and
+decrypted files.
+
+```
+nisguess2 <enc_file> <dec_file>
+```
+
+---
+
+### findcallargs — Find function calls by r4 argument
+
+Scan a SH2 ROM binary for calls to a target function where register r4
+holds a specific value. Useful for tracing how a function is invoked.
+
+```
+findcallargs <tgt> <r4val> <in_file>
+```
+
+**Example:**
+
+```
+findcallargs 0x56738 0x66 rom.bin
+```
+
+**AI notes:**
+- All addresses passed to `findcallargs` and `findrefs` are **file offsets**,
+  not hardware VAs. Ghidra loads at base 0x0 so VA = file offset in that
+  project, but hardware ROM base is 0xFFFC0000. Always confirm which address
+  space you are working in before passing a value.
+
+---
+
+### findrefs — Find memory accesses to an address
+
+Scan a SH2 ROM binary for instructions that read or write a specific
+address. Useful for tracking down what code touches a known register or
+memory location.
+
+```
+findrefs <in_file> <tgt> [<minbase>]
+```
+
+`minbase` filters out accesses below a base address (e.g. to skip ROM
+self-references and focus on peripheral I/O).
+
+**Example:**
+
+```
+findrefs rom.bin 0xffff40ff 0xffff4000
+```
+
+---
+
+### unpackdat — Unpack Nissan .dat payload
+
+Unpack a Nissan `.dat` firmware file, extracting the embedded payload.
+
+```
+unpackdat <file.dat> <out.dat>
+```
+
+---
+
+## romdb — Keyset database
+
+`romdb/keysets.csv` is a CSV of known Nissan keysets (ECUID → s27k, s36k1,
+s36k2). `nisrom` uses this database automatically when querying keys.
+
+To look up keys manually, inspect `keysets.csv` directly or grep for the
+ECUID prefix:
+
+```
+grep 6S710 romdb/keysets.csv
+```
+
+**AI notes:**
+- There is no `keyset_lookup.py` script in nissutils. Keys are found either
+  by `nisrom` (code analysis of the ROM) or by grepping `keysets.csv` directly.
+- If a keyset is not in `keysets.csv` and `nisrom` cannot derive it, the keys
+  must be found through other means (hardware extraction or algorithm analysis).
+
+---
+
+## ghidra_helpers — Ghidra ROM loader
+
+`ghidra_helpers/nissan_load.py` is a Ghidra script that auto-configures a
+Ghidra project for Nissan SH-series ECU ROMs:
+
+- Defines memory regions and interrupt vectors (IVT)
+- Labels IO peripheral registers from included CSV files
+- Supports SH7050, SH7051, SH7052, SH7055, SH7058, SH7059
+
+To use: open Script Manager in Ghidra, add the `ghidra_helpers/` directory,
+and run `nissan_load.py` immediately after importing the ROM binary.
+
+**Supported variants:** `ivt_7050.csv`, `ivt_7055.csv`, `regs_7055_180.csv`,
+`regs_7055_350.csv`, `regs_7058.csv` — pick the variant matching your ECU.

--- a/cli_utils/Makefile
+++ b/cli_utils/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -std=gnu99 -Wall -Wextra -Wpedantic -O3 -ggdb
+CFLAGS = -std=gnu99 -Wall -Wextra -O3 -ggdb -Wno-implicit-function-declaration
 
 TGTLIST = test_ecuidlist nisckfix1 nisckfix2 nisdec1 nisenc1
 TGTLIST += nisguess nisguess2 nisrom unpackdat
@@ -7,21 +7,21 @@ TGTLIST += findrefs findcallargs test_findcks test_romdb
 
 all: $(TGTLIST)
 
-nisckfix1: nisckfix1.c nislib.c
+nisckfix1: nisckfix1.c nislib.c nislib_shtools.c nisrom_finders.c
 
-nisckfix2: nisckfix2.c nislib.c
+nisckfix2: nisckfix2.c nislib.c nislib_shtools.c nisrom_finders.c
 
-nisdec1: nisdec1.c nislib.c
+nisdec1: nisdec1.c nislib.c nislib_shtools.c nisrom_finders.c
 
-nisenc1: nisenc1.c nislib.c
+nisenc1: nisenc1.c nislib.c nislib_shtools.c nisrom_finders.c
 
-nisguess: nisguess.c nislib.c
+nisguess: nisguess.c nislib.c nislib_shtools.c nisrom_finders.c
 
-nisguess2: nisguess2.c nislib.c
+nisguess2: nisguess2.c nislib.c nislib_shtools.c nisrom_finders.c
 
 nisrom: nisrom.c nislib.c nislib_shtools.c nisrom_finders.c nisrom_keyfinders.c nissan_romdefs.c nis_romdb.c libcsv/libcsv.c md5/md5.c
 
-unpackdat: unpackdat.c nislib.c
+unpackdat: unpackdat.c nislib.c nislib_shtools.c nisrom_finders.c
 
 test_ecuidlist: test_ecuidlist.c ecuid_list.c
 
@@ -31,4 +31,4 @@ findcallargs: findcallargs.c nislib.c nislib_shtools.c nisrom_finders.c
 
 test_findcks: test_findcks.c nislib.c nislib_shtools.c nisrom_finders.c
 
-test_romdb: test_romdb.c nislib.c nis_romdb.c nissan_romdefs.c libcsv/libcsv.c
+test_romdb: test_romdb.c nislib.c nislib_shtools.c nisrom_finders.c nis_romdb.c nissan_romdefs.c libcsv/libcsv.c

--- a/cli_utils/md5/md5.c
+++ b/cli_utils/md5/md5.c
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <md5.h>
+#include "md5.h"
 
 #define PUT_64BIT_LE(cp, value) do {					\
 	(cp)[7] = (value) >> 56;					\

--- a/cli_utils/nislib_shtools.c
+++ b/cli_utils/nislib_shtools.c
@@ -11,6 +11,7 @@
 #include "nislib.h"
 #include "nisrom_finders.h"
 #include "nislib_shtools.h"
+#include "nisrom_finders.h"
 #include "sh_opcodes.h"
 #include "stypes.h"
 


### PR DESCRIPTION
This PR contains two independent improvements:
1. fix: GCC 15 compatibility (cli_utils/Makefile, nislib_shtools.c, nisrom.c, nisrom_finders.c, md5/md5.c)
GCC 15 rejects implicit function declarations as errors under C99. Without this fix the build fails on any GCC 15 system:

Drop -Wpedantic from CFLAGS (triggers new pedantic errors in GCC 15)
Add -Wno-implicit-function-declaration to CFLAGS
Add nisrom_finders.c to all Makefile targets that link nislib_shtools.c (nisckfix1, nisckfix2, nisdec1, nisenc1, nisguess, nisguess2, unpackdat, test_romdb) — nislib_shtools.c calls check_ivt() which is defined in nisrom_finders.c
Add missing #include "nisrom_finders.h" in nislib_shtools.c, nisrom.c, nisrom_finders.c
Fix md5/md5.c: use local "md5.h" instead of system <md5.h>

2. docs: add USAGE.md
Adds a reference document covering all 10 CLI tools with synopsis, options, examples, and AI-agent notes for common pitfalls. Covers nisrom, nisckfix1/2, nisdec1/nisenc1, nisguess/2, findcallargs, findrefs, unpackdat, the romdb/ keyset database, and ghidra_helpers/nissan_load.py.
